### PR TITLE
Check if splitting rspec with file to run works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - run:
           name: RSpec split
           command: |
-            test_files=($(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --split-by=timings))
+            circleci tests glob "${globs[@]}" | circleci tests run --command ">split_files.txt xargs echo" --verbose --split-by=timings
+            mapfile -t test_files < split_files.txt
             echo "======"
             echo "${test_files[@]}"
             echo "======"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     docker:
       - image: cimg/ruby:2.7.4-browsers
+    paralleism: 4
     steps:
       - checkout
       - browser-tools/install-chrome
@@ -19,9 +20,11 @@ jobs:
       - ruby/install-deps:
           key: gem-2
       - run:
-          name: RSpec Tests
+          name: RSpec split
           command: |
-            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" --verbose --split-by=timings
+            test_files=($(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --verbose --split-by=timings))
+            bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out ~/rspec/rspec.xml --format progress
+
       - store_test_results:
           path: ~/rspec/rspec.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
             echo "======"
             echo "${test_files[@]}"
             echo "======"
+            echo "aaaa"
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --verbose
+            echo "aaaa"
             bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out ~/rspec/rspec.xml --format progress
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             echo "${test_files[@]}"
             echo "======"
             echo "aaaa"
-            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --verbose
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="echo xargs" --verbose
             echo "aaaa"
             bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out ~/rspec/rspec.xml --format progress
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           command: |
             google-chrome --version
-            chromedriver --version
+            # chromedriver --version
           name: Check chrome install
       - ruby/install-deps:
           key: gem-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 orbs:
   ruby: circleci/ruby@2.0.1
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.2
 jobs:
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,10 @@ jobs:
             echo "======"
             echo "${test_files[@]}"
             echo "======"
-            echo "aaaa"
+            echo "aaacccc"
             circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="echo xargs" --verbose
-            echo "aaaa"
+            echo "aaaabbb"
+            sleep 500
             bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out ~/rspec/rspec.xml --format progress
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: RSpec split
           command: |
-            circleci tests glob "${globs[@]}" | circleci tests run --command ">split_files.txt xargs echo" --verbose --split-by=timings
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command ">split_files.txt xargs echo" --verbose --split-by=timings
             mapfile -t test_files < split_files.txt
             echo "======"
             echo "${test_files[@]}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
           name: RSpec split
           command: |
             test_files=($(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --verbose --split-by=timings))
+            echo "======"
+            echo "${test_files[@]}"
+            echo "======"
             bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out ~/rspec/rspec.xml --format progress
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: RSpec split
           command: |
-            test_files=($(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --verbose --split-by=timings))
+            test_files=($(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --split-by=timings))
             echo "======"
             echo "${test_files[@]}"
             echo "======"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     docker:
       - image: cimg/ruby:2.7.4-browsers
-    paralleism: 4
+    parallelism: 4
     steps:
       - checkout
       - browser-tools/install-chrome


### PR DESCRIPTION
## Check 

I would like to check if splitting the rspec file runs all test or skips test if there is no file specified

```rb
test_files=($(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs echo" --verbose --split-by=timings))
bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out ~/rspec/rspec.xml --format progress
```